### PR TITLE
Change case of include so App.vue compiles on Linux.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
 import { defineComponent } from 'vue';
 
 // Modules
-import { AudioInput } from './modules/audio/input/audioInput.js';
+import { AudioInput } from './modules/audio/input/AudioInput.js';
 import { Metaverse } from './modules/metaverse/metaverse.js';
 import { Entities } from './modules/entities/entities.js';
 import { Explore } from './modules/explore/explore.js';


### PR DESCRIPTION
A small alphabetic case change on an import statement. This is probably due to the directory lookup differences between Linux and Windows.