### PR TITLE
Create and implement custom loading screen.

### DIFF
--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -1,0 +1,69 @@
+<!--
+//  LoadingScreen.vue
+//
+//  Created by Giga on 27 Aug 2022.
+//  Copyright 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+-->
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+    name: "LoadingScreen"
+});
+</script>
+
+<template>
+    <div
+        id="loadingScreen"
+        @click.stop=""
+    >
+        <div class="inner">
+            <img src="/assets/vircadia-icon.svg" draggable="false" alt="" width="200" height="200">
+            <q-spinner-tail
+                size="xl"
+            />
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+#loadingScreen {
+    position: absolute;
+    z-index: 100;
+    inset: 0px;
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    background-color: #000;
+    user-select: none;
+
+    & > .inner {
+        display: flex;
+        flex-flow: column nowrap;
+        justify-content: center;
+        align-items: center;
+        width: 250px;
+        height: 250px;
+        aspect-ratio: 1;
+    }
+
+    img {
+        display: block;
+        width: 200px;
+        height: 200px;
+        aspect-ratio: 1;
+    }
+
+    .q-spinner {
+        position: absolute;
+        transform: scale(5);
+    }
+}
+</style>

--- a/src/components/MainScene.vue
+++ b/src/components/MainScene.vue
@@ -27,6 +27,7 @@
             ref="renderCanvas"
             class="renderCanvas"
         />
+        <LoadingScreen ref="loadingScreen" />
         <slot name="manager" />
     </q-page>
 </template>
@@ -38,6 +39,8 @@ import { Mutations as StoreMutations } from "@Store/index";
 import { AudioMgr } from "@Modules/scene/audio";
 import { Renderer } from "@Modules/scene/renderer";
 // import Log from "@Modules/debugging/log";
+
+import LoadingScreen from "@Components/LoadingScreen.vue";
 
 type Nullable<T> = T | null | undefined;
 
@@ -53,6 +56,10 @@ export default defineComponent({
             type: Boolean,
             required: true
         }
+    },
+
+    components: {
+        LoadingScreen
     },
 
     $refs!: {   // definition to make this.$ref work with TypeScript
@@ -98,7 +105,9 @@ export default defineComponent({
     mounted: async function() {
         // Initialize the graphics display
         const canvas = this.$refs.renderCanvas as HTMLCanvasElement;
-        await Renderer.initialize(canvas);
+        const loadingScreenComponent = this.$refs.loadingScreen as typeof LoadingScreen;
+        const loadingScreenElement = loadingScreenComponent.$el as HTMLElement;
+        await Renderer.initialize(canvas, loadingScreenElement);
         this.$store.commit(StoreMutations.MUTATE, {
             property: "renderer/focusSceneId",
             value: 0

--- a/src/modules/scene/LoadingScreen.ts
+++ b/src/modules/scene/LoadingScreen.ts
@@ -1,0 +1,42 @@
+//
+//  LoadingScreen.ts
+//
+//  Created by Giga on 27 Aug 2022.
+//  Copyright 2022 Vircadia contributors.
+//  Copyright 2022 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { ILoadingScreen } from "@babylonjs/core";
+
+export class CustomLoadingScreen implements ILoadingScreen {
+    loadingUIElement: HTMLElement;
+    loadingUIBackgroundColor: string;
+    loadingUIText: string;
+    transitionTime: number;
+
+    constructor(element: HTMLElement) {
+        this.loadingUIElement = element;
+        this.loadingUIBackgroundColor = "#000";
+        this.loadingUIText = "";
+        this.transitionTime = 0.5;
+    }
+
+    displayLoadingUI(): void {
+        if (this.loadingUIElement) {
+            this.loadingUIElement.style.opacity = "1";
+            this.loadingUIElement.style.transition = `${this.transitionTime}s linear opacity`;
+            this.loadingUIElement.style.pointerEvents = "all";
+        }
+    }
+
+    hideLoadingUI(): void {
+        if (this.loadingUIElement) {
+            this.loadingUIElement.style.opacity = "0";
+            this.loadingUIElement.style.transition = `${this.transitionTime}s linear opacity`;
+            this.loadingUIElement.style.pointerEvents = "none";
+        }
+    }
+}

--- a/src/modules/scene/renderer.ts
+++ b/src/modules/scene/renderer.ts
@@ -19,6 +19,7 @@ import { DomainMgr } from "@Modules/domain";
 
 // General Modules
 import { VScene } from "@Modules/scene/vscene";
+import { CustomLoadingScreen } from "@Modules/scene/LoadingScreen";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import Log from "@Modules/debugging/log";
@@ -29,7 +30,7 @@ export const Renderer = {
     _webgpuSupported: false,
 
     // eslint-disable-next-line @typescript-eslint/require-await
-    async initialize(pCanvas: HTMLCanvasElement): Promise<void> {
+    async initialize(pCanvas: HTMLCanvasElement, pLoadingScreen: HTMLElement): Promise<void> {
 
         this._webgpuSupported = await WebGPUEngine.IsSupportedAsync;
         if (this._webgpuSupported) {
@@ -48,9 +49,13 @@ export const Renderer = {
                     ]
                 }
             });
+            Renderer._engine.loadingScreen = new CustomLoadingScreen(pLoadingScreen);
             await (Renderer._engine as WebGPUEngine).initAsync();
+            Renderer._engine.displayLoadingUI();
         } else {
             Renderer._engine = new Engine(pCanvas, true);
+            Renderer._engine.loadingScreen = new CustomLoadingScreen(pLoadingScreen);
+            Renderer._engine.displayLoadingUI();
         }
 
         this._renderingScenes = new Array<VScene>();


### PR DESCRIPTION
This replaces the default Babylon loading screen in the Babylon engine.
No additional actions need to be taken to show/hide the custom loading screen as this is handled by Babylon.