### PR TITLE
Improve the appearance of nametags.

### DIFF
--- a/src/modules/scene/controllers/domainController.ts
+++ b/src/modules/scene/controllers/domainController.ts
@@ -207,7 +207,7 @@ export class DomainController extends ScriptComponent {
             const domain = avatarList.getAvatar(sessionID);
 
             if (domain.skeletonModelURL !== "") {
-                this._vscene?.loadAvatar(sessionID.stringify(), domain);
+                this._vscene?.loadAvatar(sessionID, domain);
             }
 
             domain.skeletonModelURLChanged.connect(() => {
@@ -219,7 +219,7 @@ export class DomainController extends ScriptComponent {
     private _handleAvatarRemoved = (sessionID: Uuid): void => {
         Log.debug(Log.types.AVATAR,
             `handleAvatarRemoved. Session ID: ${sessionID.stringify()}`);
-        this._vscene?.unloadAvatar(sessionID.stringify());
+        this._vscene?.unloadAvatar(sessionID);
 
     };
 
@@ -227,7 +227,7 @@ export class DomainController extends ScriptComponent {
         Log.debug(Log.types.AVATAR,
             `handleAvatarSkeletonModelURLChanged. Session ID: ${sessionID.stringify()}, ${domain.skeletonModelURL}`);
 
-        this._vscene?.loadAvatar(sessionID.stringify(), domain);
+        this._vscene?.loadAvatar(sessionID, domain);
     }
 
     private _handleOnEntityServerStateChanged(state: AssignmentClientState): void {

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -584,11 +584,11 @@ export class VScene {
         nametagMaterial.alphaMode = 6; // One one.
         nametagMaterial.disableLighting = true;
 
-        const nametagArrowMaterial = new StandardMaterial("NametagArrowMaterial", this._scene);
-        nametagArrowMaterial.diffuseColor = tagBackgroundColor;
-        nametagArrowMaterial.specularColor = tagBackgroundColor;
-        nametagArrowMaterial.emissiveColor = tagBackgroundColor;
-        nametagArrowMaterial.disableLighting = true;
+        const nametagBackgroundMaterial = new StandardMaterial("NametagBackgroundMaterial", this._scene);
+        nametagBackgroundMaterial.diffuseColor = tagBackgroundColor;
+        nametagBackgroundMaterial.specularColor = tagBackgroundColor;
+        nametagBackgroundMaterial.emissiveColor = tagBackgroundColor;
+        nametagBackgroundMaterial.disableLighting = true;
 
         // Mesh.
         const nametagPlane = MeshBuilder.CreatePlane("Nametag", {
@@ -609,7 +609,7 @@ export class VScene {
             sideOrientation: Mesh.DOUBLESIDE,
             updatable: true
         }, this._scene);
-        nametagBackgroundPlane.material = nametagArrowMaterial;
+        nametagBackgroundPlane.material = nametagBackgroundMaterial;
         nametagBackgroundPlane.parent = nametagPlane;
 
         // Rounded corners.
@@ -631,7 +631,7 @@ export class VScene {
         nametagCorners.push(MeshBuilder.CreateDisc("NametagBottomRightCorner", nametagCornerOptions, this._scene));
         nametagCorners.push(MeshBuilder.CreateDisc("NametagBottomLeftCorner", nametagCornerOptions, this._scene));
         nametagCorners.forEach((cornerMesh, index) => {
-            cornerMesh.material = nametagArrowMaterial;
+            cornerMesh.material = nametagBackgroundMaterial;
             cornerMesh.parent = nametagPlane;
             cornerMesh.position = nametagCornerPositions[index];
         });
@@ -651,7 +651,7 @@ export class VScene {
         nametagEdges.push(MeshBuilder.CreatePlane("NametagLeftEdge", nametagEdgeOptions, this._scene));
         nametagEdges.push(MeshBuilder.CreatePlane("NametagRightEdge", nametagEdgeOptions, this._scene));
         nametagEdges.forEach((cornerMesh, index) => {
-            cornerMesh.material = nametagArrowMaterial;
+            cornerMesh.material = nametagBackgroundMaterial;
             cornerMesh.parent = nametagPlane;
             cornerMesh.position = nametagEdgePositions[index];
         });
@@ -664,7 +664,7 @@ export class VScene {
             sideOrientation: Mesh.DOUBLESIDE,
             updatable: true
         }, this._scene);
-        nametagArrow.material = nametagArrowMaterial;
+        nametagArrow.material = nametagBackgroundMaterial;
         nametagArrow.parent = nametagPlane;
         nametagArrow.position = new Vector3(0, -(tagHeight / 2 + nametagArrowSize / 4), 0);
         nametagArrow.rotation.z = -Math.PI / 2;

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -13,7 +13,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable class-methods-use-this */
 
-import { AnimationGroup, Engine, Scene,
+import { AnimationGroup, Engine, Scene, Color3,
     ActionManager, ActionEvent, ExecuteCodeAction, ArcRotateCamera, Camera,
     Observable, Nullable, AmmoJSPlugin, Quaternion, Vector3, StandardMaterial,
     Mesh, MeshBuilder, DynamicTexture, Color4, DefaultRenderingPipeline } from "@babylonjs/core";
@@ -510,8 +510,11 @@ export class VScene {
 
     // TODO: Move all nametag code into a dedicated module.
     private _loadNametag(avatar: GameObject, avatarHeight: number, name: string) : Mesh {
+        const fontSize = 70;
         const characterWidth = 38.5;
         const tagWidth = (name.length + 2) * characterWidth;
+        const tagHeight = 0.1;
+        const tagBackgroundColor = new Color3(0.07, 0.07, 0.07);
 
         // Texture.
         const nametagTextureResolution = 100;
@@ -522,10 +525,10 @@ export class VScene {
         nametagTexture.drawText(
             name,
             tagWidth / 2 - name.length / 2 * characterWidth, // Center the name on the tag.
-            70,
-            "70px monospace",
+            fontSize,
+            `${fontSize}px monospace`,
             "white",
-            "#121212",
+            tagBackgroundColor.toHexString(),
             true,
             true
         );
@@ -540,7 +543,7 @@ export class VScene {
         // Mesh.
         const nametagPlane = MeshBuilder.CreatePlane("Nametag", {
             width: 0.1 * tagWidth / nametagTextureResolution,
-            height: 0.1,
+            height: tagHeight,
             sideOrientation: Mesh.DOUBLESIDE,
             updatable: true
         }, this._scene);

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -616,10 +616,10 @@ export class VScene {
             updatable: true
         };
         const nametagCornerPositions = [
-            new Vector3(-tagWidth / 2, tagHeight / 2 - tagCornerRadius, 0),
-            new Vector3(tagWidth / 2, tagHeight / 2 - tagCornerRadius, 0),
-            new Vector3(tagWidth / 2, -tagHeight / 2 + tagCornerRadius, 0),
-            new Vector3(-tagWidth / 2, -tagHeight / 2 + tagCornerRadius, 0)
+            new Vector3(-tagWidth / 2, tagHeight / 2 - tagCornerRadius, -0.001),
+            new Vector3(tagWidth / 2, tagHeight / 2 - tagCornerRadius, -0.001),
+            new Vector3(tagWidth / 2, -tagHeight / 2 + tagCornerRadius, -0.001),
+            new Vector3(-tagWidth / 2, -tagHeight / 2 + tagCornerRadius, -0.001)
         ];
         nametagCorners.push(MeshBuilder.CreateDisc("NametagTopLeftCorner", nametagCornerOptions, this._scene));
         nametagCorners.push(MeshBuilder.CreateDisc("NametagTopRightCorner", nametagCornerOptions, this._scene));
@@ -640,8 +640,8 @@ export class VScene {
             updatable: true
         };
         const nametagEdgePositions = [
-            new Vector3(-tagWidth / 2 - tagCornerRadius / 2, 0, 0),
-            new Vector3(tagWidth / 2 + tagCornerRadius / 2, 0, 0)
+            new Vector3(-tagWidth / 2 - tagCornerRadius / 2, 0, -0.001),
+            new Vector3(tagWidth / 2 + tagCornerRadius / 2, 0, -0.001)
         ];
         nametagEdges.push(MeshBuilder.CreatePlane("NametagLeftEdge", nametagEdgeOptions, this._scene));
         nametagEdges.push(MeshBuilder.CreatePlane("NametagRightEdge", nametagEdgeOptions, this._scene));

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -568,10 +568,7 @@ export class VScene {
             updatable: true
         }, this._scene);
         nametagArrow.material = nametagArrowMaterial;
-        nametagArrow.billboardMode = Mesh.BILLBOARDMODE_Y;
         nametagArrow.parent = nametagPlane;
-        nametagArrow.isPickable = false;
-        nametagArrow.renderingGroupId = MASK_MESH_RENDER_GROUP_ID;
 
         // Position the nametag above the center of the avatar.
         const positionOffset = new Vector3(0, 0.15, 0);

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -540,6 +540,12 @@ export class VScene {
         nametagMaterial.emissiveTexture = nametagTexture;
         nametagMaterial.disableLighting = true;
 
+        const nametagArrowMaterial = new StandardMaterial("NametagArrowMaterial", this._scene);
+        nametagArrowMaterial.diffuseColor = tagBackgroundColor;
+        nametagArrowMaterial.specularColor = tagBackgroundColor;
+        nametagArrowMaterial.emissiveColor = new Color3(0.005, 0.005, 0.005);
+        nametagMaterial.disableLighting = true;
+
         // Mesh.
         const nametagPlane = MeshBuilder.CreatePlane("Nametag", {
             width: 0.1 * tagWidth / nametagTextureResolution,
@@ -552,6 +558,21 @@ export class VScene {
         nametagPlane.parent = avatar;
         nametagPlane.isPickable = false;
         nametagPlane.renderingGroupId = MASK_MESH_RENDER_GROUP_ID;
+
+        // Arrow mesh.
+        const nametagArrowSize = 0.02;
+        const nametagArrow = MeshBuilder.CreateDisc("NametagArrow", {
+            radius: nametagArrowSize,
+            tessellation: 3,
+            sideOrientation: Mesh.DOUBLESIDE,
+            updatable: true
+        }, this._scene);
+        nametagArrow.material = nametagArrowMaterial;
+        nametagArrow.billboardMode = Mesh.BILLBOARDMODE_Y;
+        nametagArrow.parent = nametagPlane;
+        nametagArrow.isPickable = false;
+        nametagArrow.renderingGroupId = MASK_MESH_RENDER_GROUP_ID;
+
         // Position the nametag above the center of the avatar.
         const positionOffset = new Vector3(0, 0.15, 0);
         nametagPlane.position = new Vector3(
@@ -559,6 +580,9 @@ export class VScene {
             avatarHeight + positionOffset.y,
             positionOffset.z
         );
+        nametagArrow.position = new Vector3(0, -(tagHeight / 2 + nametagArrowSize / 4), 0);
+        nametagArrow.rotation.z = -Math.PI / 2;
+        nametagArrow.scaling.x = 0.5;
 
         return nametagPlane;
     }


### PR DESCRIPTION
- Add an arrow to the bottom pointing to the player owning the nametag.
- Add rounded corners to match the style of the rest of the UI.
- Show a player's nametag in the `primary` theme colour if they are an admin on the current domain:
  ![image](https://user-images.githubusercontent.com/22832983/214979038-55085de6-f1ca-4e26-8518-945ebdfd4951.png)

- More effectively prevent duplicate nametags from remaining attached to an avatar after an attempt to unload them.