### PR TITLE
Account for a difference in the hip positions of the avatar and animation model.

### DIFF
--- a/src/modules/scene/resource.ts
+++ b/src/modules/scene/resource.ts
@@ -86,12 +86,12 @@ export class ResourceManager {
             sourceAnimGroup.targetedAnimations.forEach((targetAnim) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
                 if (targetAnim.target?.name === "Hips") {
-                    // Recaculate the postion and roatation of the Hip animation key.
+                    // Recalculate the position and rotation of the Hip animation key.
                     if (targetAnim.animation.targetProperty === "position") {
                         const anim = targetAnim.animation.clone();
                         const keys = anim.getKeys();
                         keys.forEach((keyFrame, index) => {
-                            // Apply the roation and scale of the Armatue node.
+                            // Apply the rotation and scale of the Armature node.
                             let pos = keyFrame.value as Vector3;
                             pos = pos.applyRotationQuaternion(mesh.rotationQuaternion as Quaternion);
                             pos = pos.multiply(mesh.scaling);
@@ -110,7 +110,7 @@ export class ResourceManager {
                         const anim = targetAnim.animation.clone();
                         const keys = anim.getKeys();
                         keys.forEach((keyFrame) => {
-                            // Apply the roation of the Armatue node.
+                            // Apply the rotation of the Armature node.
                             const rot = keyFrame.value as Quaternion;
                             if (mesh.rotationQuaternion) {
                                 keyFrame.value = mesh.rotationQuaternion.multiply(rot);

--- a/src/modules/scene/resource.ts
+++ b/src/modules/scene/resource.ts
@@ -64,7 +64,7 @@ export class ResourceManager {
     }
 
 
-    public async loadAvatarAnimations(modelUrl: string, hipPosition = Vector3.Zero()): Promise<IAvatarAnimationResult> {
+    public async loadAvatarAnimations(modelUrl: string, hipPosition?: Vector3): Promise<IAvatarAnimationResult> {
         const modelAssetName = modelUrl.split("/");
         const result = await SceneLoader.ImportMeshAsync(
             "",
@@ -100,7 +100,9 @@ export class ResourceManager {
                             if (index === 0) {
                                 animationInitialHipPosition = pos.clone();
                             }
-                            offset = animationInitialHipPosition.y - hipPosition.y;
+                            if (hipPosition) {
+                                offset = animationInitialHipPosition.y - hipPosition.y;
+                            }
                             pos.y = pos.y - offset;
                             keyFrame.value = pos;
                         });

--- a/src/modules/scene/resource.ts
+++ b/src/modules/scene/resource.ts
@@ -173,14 +173,6 @@ export class ResourceManager {
             // For matching the orientation of vircadia
             mesh.rotationQuaternion = Quaternion.FromEulerAngles(0, Math.PI, 0);
 
-            // make the pivot to the center of the bounding
-            const bounding = mesh.getHierarchyBoundingVectors(true);
-            const pivot = bounding.max.add(bounding.min).scale(-0.5);
-            // add some offset
-            pivot.addInPlace(new Vector3(0, -0.1, 0));
-            // move the mesh to the pivot
-            mesh.position = pivot;
-
             const skeleton = result.skeletons.length > 0 ? result.skeletons[0] : null;
 
             return {

--- a/src/modules/scene/resource.ts
+++ b/src/modules/scene/resource.ts
@@ -64,7 +64,7 @@ export class ResourceManager {
     }
 
 
-    public async loadAvatarAnimations(modelUrl: string): Promise<IAvatarAnimationResult> {
+    public async loadAvatarAnimations(modelUrl: string, hipPosition = Vector3.Zero()): Promise<IAvatarAnimationResult> {
         const modelAssetName = modelUrl.split("/");
         const result = await SceneLoader.ImportMeshAsync(
             "",
@@ -78,22 +78,31 @@ export class ResourceManager {
 
         const mesh = result.meshes[0].getChildren()[0] as AbstractMesh;
         const animationGroups = new Array<AnimationGroup>();
+        let animationInitialHipPosition = Vector3.Zero();
 
         result.animationGroups.forEach((sourceAnimGroup) => {
             const animGroup = new AnimationGroup(sourceAnimGroup.name);
-            // trim unnecessary animation data
+            // Trim unnecessary animation data.
             sourceAnimGroup.targetedAnimations.forEach((targetAnim) => {
                 // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-                if (targetAnim.target.name === "Hips") {
-                    // recaculate the postion and roatation quaternion animation key of Hip
+                if (targetAnim.target?.name === "Hips") {
+                    // Recaculate the postion and roatation of the Hip animation key.
                     if (targetAnim.animation.targetProperty === "position") {
                         const anim = targetAnim.animation.clone();
                         const keys = anim.getKeys();
-                        keys.forEach((keyFrame) => {
-                            // apply the roation and scale of Armatue node
+                        keys.forEach((keyFrame, index) => {
+                            // Apply the roation and scale of the Armatue node.
                             let pos = keyFrame.value as Vector3;
                             pos = pos.applyRotationQuaternion(mesh.rotationQuaternion as Quaternion);
-                            keyFrame.value = pos.multiply(mesh.scaling);
+                            pos = pos.multiply(mesh.scaling);
+                            // Account for a difference in the hip positions of the avatar and animation model.
+                            let offset = 0;
+                            if (index === 0) {
+                                animationInitialHipPosition = pos.clone();
+                            }
+                            offset = animationInitialHipPosition.y - hipPosition.y;
+                            pos.y = pos.y - offset;
+                            keyFrame.value = pos;
                         });
                         animGroup.addTargetedAnimation(anim, targetAnim.target);
 
@@ -101,7 +110,7 @@ export class ResourceManager {
                         const anim = targetAnim.animation.clone();
                         const keys = anim.getKeys();
                         keys.forEach((keyFrame) => {
-                            // apply the roation Armatue node
+                            // Apply the roation of the Armatue node.
                             const rot = keyFrame.value as Quaternion;
                             if (mesh.rotationQuaternion) {
                                 keyFrame.value = mesh.rotationQuaternion.multiply(rot);
@@ -110,12 +119,12 @@ export class ResourceManager {
                         animGroup.addTargetedAnimation(targetAnim.animation, targetAnim.target);
                     }
                 } else if (targetAnim.animation.targetProperty === "rotationQuaternion") {
-                // keep rotationQuaternion animation of all other nodes
+                    // Keep the original position and rotation of all other nodes.
                     animGroup.addTargetedAnimation(targetAnim.animation, targetAnim.target);
                 }
             });
 
-            // remove from scene to prevent animation group is disposed when dispose scene
+            // Remove from the scene to prevent the animation group from being disposed when the scene is disposed.
             this._scene.removeAnimationGroup(animGroup);
 
             animationGroups.push(animGroup);

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -349,7 +349,7 @@ export class VScene {
             const defaultColliderProperties = {
                 radius: 0.3,
                 height: 1.8,
-                offset: new Vector3(0, -0.1, -0.04), // Offset coordinates are local (relative to the avatar).
+                offset: new Vector3(0, 0, -0.04), // Offset coordinates are local (relative to the avatar).
                 mass: 1,
                 friction: 3
             };

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -299,10 +299,6 @@ export class VScene {
         if (!this._avatarIsLoading && this._resourceManager) {
             this._avatarIsLoading = true;
             const lastQueuedModelURL = this._avatarLoadQueue.pop(); // Only load the last model in the request queue.
-            if (this._avatarAnimationGroups.length === 0) {
-                const result = await this._resourceManager.loadAvatarAnimations(AvatarAnimationUrl);
-                this._avatarAnimationGroups = result.animGroups;
-            }
             if (lastQueuedModelURL) {
                 // Ignore repeated attempts to load the same model, unless required.
                 if (this._myAvatarModelURL === lastQueuedModelURL && this._myAvatar && !reload) {
@@ -346,6 +342,13 @@ export class VScene {
             }
             const avatarHeight = boundingVectors.max.y - boundingVectors.min.y;
 
+            const hipPosition = result.skeleton?.bones.find((bone) => bone.name === "Hips")?.position;
+
+            // Reload the avatar animations file in case the new avatar is a different size than the previous one.
+            // The browser cache will prevent this from being fetched over the network if the avatar is switched frequently.
+            const animResult = await this._resourceManager.loadAvatarAnimations(AvatarAnimationUrl, hipPosition);
+            this._avatarAnimationGroups = animResult.animGroups;
+
             const defaultColliderProperties = {
                 radius: 0.3,
                 height: 1.8,
@@ -366,7 +369,7 @@ export class VScene {
                 avatarHeight || defaultColliderProperties.height,
                 new Vector3(
                     defaultColliderProperties.offset.x,
-                    boundingVectors.max.y - defaultColliderProperties.offset.y,
+                    (avatarHeight || defaultColliderProperties.height) / 2 + defaultColliderProperties.offset.y,
                     defaultColliderProperties.offset.z
                 )
             );


### PR DESCRIPTION
Short avatars will no longer appear to float, and tall avatars will no longer appear to clip into the ground.
![image](https://user-images.githubusercontent.com/22832983/217166213-17642073-57c2-49c4-a746-6d096ce3b8c1.png)
