### PR TITLE
Redesign the list items in the People menu.

### DIFF
--- a/src/components/MainScene.vue
+++ b/src/components/MainScene.vue
@@ -236,7 +236,7 @@ export default defineComponent({
             }
         });
         // NOTE: The scene must be loaded to register domain events before connecting to the domain.
-        await scene.load(undefined, AvatarStoreInterface.getActiveModelData("file") as string);
+        await scene.load(undefined, AvatarStoreInterface.getActiveModelData("file"));
         await this.connect();
 
         Renderer.startRenderLoop([scene]);

--- a/src/components/overlays/avatar/Avatar.vue
+++ b/src/components/overlays/avatar/Avatar.vue
@@ -526,7 +526,7 @@ export default defineComponent({
         },
         activeModelNameStore: {
             get: function(): string {
-                return AvatarStoreInterface.getActiveModelData("name") as string;
+                return AvatarStoreInterface.getActiveModelData("name");
             },
             set: function(pVal: string): void {
                 AvatarStoreInterface.setActiveModelData("name", pVal);
@@ -534,7 +534,7 @@ export default defineComponent({
         },
         activeModelFileStore: {
             get: function(): string {
-                return AvatarStoreInterface.getActiveModelData("file") as string;
+                return AvatarStoreInterface.getActiveModelData("file");
             },
             set: function(pVal: string): void {
                 AvatarStoreInterface.setActiveModelData("file", pVal);
@@ -575,7 +575,7 @@ export default defineComponent({
                 this.loadingAvatar = true;
                 AvatarStoreInterface.setActiveModel(modelId);
                 const scene = Renderer.getScene();
-                await scene.loadMyAvatar(AvatarStoreInterface.getModelData(modelId, "file") as string, reload);
+                await scene.loadMyAvatar(AvatarStoreInterface.getModelData(modelId, "file"), reload);
                 this.loadingAvatar = false;
             }
         },

--- a/src/components/overlays/people/People.vue
+++ b/src/components/overlays/people/People.vue
@@ -9,6 +9,29 @@
 -->
 
 <style lang="scss" scoped>
+.volumeIcon {
+    --offset: 0.15em;
+    --volume: 0%;
+    position: relative;
+    display: inline-flex;
+    width: 1.5em;
+    height: 1.25em;
+    color: inherit;
+    background-color: currentColor;
+    clip-path: polygon(
+        100% 100%,
+        0% 100%,
+        100% 0%,
+        100% 100%,
+        calc(100% - var(--offset)) calc(100% - var(--offset)),
+        calc(100% - var(--offset)) calc(var(--offset) * 2.1),
+        calc((var(--offset) * 2.7) + (var(--volume) * 0.75 - var(--offset)))
+        calc(var(--offset) * 2.1 + (95% - var(--volume)) * 0.78),
+        calc((var(--offset) * 2.7) + (var(--volume) * 0.75 - var(--offset))) calc(100% - var(--offset)),
+        calc(100% - var(--offset)) calc(100% - var(--offset))
+    );
+    transform: translate(-5%, -5%);
+}
 </style>
 
 <template>
@@ -120,11 +143,7 @@
                                             />
                                         </template>
                                     </div>
-                                    <div
-                                        style="all: inherit;position: relative;gap: 16px;"
-                                        @mouseenter="showMoreOptions[avaInfo.sessionId.stringify()] = true"
-                                        @mouseleave="showMoreOptions[avaInfo.sessionId.stringify()] = false"
-                                    >
+                                    <div style="all: inherit;position: relative;">
                                         <q-slider
                                             :min="0"
                                             :max="100"
@@ -135,7 +154,7 @@
                                             style="
                                                 position: absolute;
                                                 width: calc(48px * 2.5);
-                                                margin-right: 34px;
+                                                margin-right: 48px;
                                             "
                                             :style="{
                                                 opacity: showMoreOptions[avaInfo.sessionId.stringify()] ? 1 : 0,
@@ -145,20 +164,35 @@
                                             }"
                                             :model-value="avaInfo.volume"
                                             @update:model-value="(value) => setVolume(avaInfo.sessionId, value)"
-                                            @mouseenter="showMoreOptions[avaInfo.sessionId.stringify()] = true"
                                         />
                                         <q-btn
-                                            :icon="avaInfo.muted || avaInfo.volume === 0 ? 'volume_off' : 'volume_up'"
                                             :text-color="avaInfo.muted || avaInfo.volume === 0 ? 'red' : 'primary'"
                                             flat
                                             round
                                             dense
                                             ripple
-                                            :title="avaInfo.muted || avaInfo.volume === 0
-                                                ? `Unmute ${avaInfo.displayName}` : `Mute ${avaInfo.displayName}`"
-                                            @click.stop="complementMuted(avaInfo)"
-                                        />
+                                            :title="`Adjust ${
+                                                avaInfo.displayName[avaInfo.displayName.length - 1]?.toLowerCase() === 's'
+                                                ? avaInfo.displayName + '\''
+                                                : avaInfo.displayName + '\'s'
+                                            } volume`"
+                                            @click.stop="showMoreOptions[avaInfo.sessionId.stringify()] =
+                                                !showMoreOptions[avaInfo.sessionId.stringify()]"
+                                        >
+                                            <span class="volumeIcon" :style="`--volume: ${avaInfo.volume}%;`"></span>
+                                        </q-btn>
                                     </div>
+                                    <q-btn
+                                        :icon="avaInfo.muted || avaInfo.volume === 0 ? 'volume_off' : 'volume_up'"
+                                        :text-color="avaInfo.muted || avaInfo.volume === 0 ? 'red' : 'primary'"
+                                        flat
+                                        round
+                                        dense
+                                        ripple
+                                        :title="avaInfo.muted || avaInfo.volume === 0
+                                            ? `Unmute ${avaInfo.displayName}` : `Mute ${avaInfo.displayName}`"
+                                        @click.stop="complementMuted(avaInfo)"
+                                    />
                                 </div>
                             </div>
                         </q-item-section>

--- a/src/components/overlays/people/People.vue
+++ b/src/components/overlays/people/People.vue
@@ -108,10 +108,10 @@
                                 >
                                     <div
                                         :style="{
-                                            opacity: !showMoreOptions[avaInfo.sessionId.stringify()] ? 1 : 0,
-                                            transition: !showMoreOptions[avaInfo.sessionId.stringify()]
+                                            opacity: !showVolumeSlider[avaInfo.sessionId.stringify()] ? 1 : 0,
+                                            transition: !showVolumeSlider[avaInfo.sessionId.stringify()]
                                                 ? '0.25s ease opacity' : 'none',
-                                            pointerEvents: !showMoreOptions[avaInfo.sessionId.stringify()] ? 'all' : 'none'
+                                            pointerEvents: !showVolumeSlider[avaInfo.sessionId.stringify()] ? 'all' : 'none'
                                         }"
                                     >
                                         <q-btn
@@ -183,10 +183,10 @@
                                             :title="`Volume: ${avaInfo.volume}%`"
                                             class="volumeSlider"
                                             :style="{
-                                                opacity: showMoreOptions[avaInfo.sessionId.stringify()] ? 1 : 0,
-                                                transition: showMoreOptions[avaInfo.sessionId.stringify()]
+                                                opacity: showVolumeSlider[avaInfo.sessionId.stringify()] ? 1 : 0,
+                                                transition: showVolumeSlider[avaInfo.sessionId.stringify()]
                                                     ? '0.25s ease opacity' : 'none',
-                                                pointerEvents: showMoreOptions[avaInfo.sessionId.stringify()] ? 'all' : 'none'
+                                                pointerEvents: showVolumeSlider[avaInfo.sessionId.stringify()] ? 'all' : 'none'
                                             }"
                                             :model-value="avaInfo.volume"
                                             @update:model-value="(value) => setVolume(avaInfo.sessionId, value)"
@@ -202,8 +202,8 @@
                                                 ? avaInfo.displayName + '\''
                                                 : avaInfo.displayName + '\'s'
                                             } volume`"
-                                            @click.stop="showMoreOptions[avaInfo.sessionId.stringify()] =
-                                                !showMoreOptions[avaInfo.sessionId.stringify()]"
+                                            @click.stop="showVolumeSlider[avaInfo.sessionId.stringify()] =
+                                                !showVolumeSlider[avaInfo.sessionId.stringify()]"
                                         >
                                             <span class="volumeIcon" :style="`--volume: ${avaInfo.volume}%;`"></span>
                                         </q-btn>
@@ -262,7 +262,7 @@ export default defineComponent({
     },
 
     data: () => ({
-        showMoreOptions: {} as { [key: string]: boolean },
+        showVolumeSlider: {} as { [key: string]: boolean },
         canKick: false
     }),
 

--- a/src/components/overlays/people/People.vue
+++ b/src/components/overlays/people/People.vue
@@ -32,6 +32,35 @@
     );
     transform: translate(-5%, -5%);
 }
+.volumeSlider {
+    position: absolute;
+    z-index: 1;
+    width: calc(48px * 2.5);
+    margin-right: 50px;
+}
+.volumeSlider::before {
+    content: '';
+    position: absolute;
+    z-index: -2;
+    inset: 0 -12px;
+    background-color: $dark;
+    border: 1px solid #8882;
+    border-radius: 5px;
+}
+.volumeSlider::after {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    top: 50%;
+    right: -12px;
+    width: 0.75em;
+    height: 0.75em;
+    background-color: $dark;
+    border: 1px solid #8882;
+    border-bottom: unset;
+    border-left: unset;
+    transform: translate(calc(50% - 1px), -50%) rotate(45deg);
+}
 </style>
 
 <template>
@@ -60,7 +89,7 @@
                     <q-item
                         v-for="avaInfo in $store.state.avatars.avatarsInfo.values()"
                         :key="avaInfo.sessionId.stringify()"
-                        class="q-mb-none q-py-sm"
+                        class="q-mb-none q-pa-sm"
                         dense
                     >
                         <q-item-section avatar class="q-gutter-y-sm">
@@ -149,13 +178,10 @@
                                             :max="100"
                                             :step="5"
                                             snap
+                                            dark
                                             :color="avaInfo.muted || avaInfo.volume === 0 ? 'red' : 'primary'"
                                             :title="`Volume: ${avaInfo.volume}%`"
-                                            style="
-                                                position: absolute;
-                                                width: calc(48px * 2.5);
-                                                margin-right: 48px;
-                                            "
+                                            class="volumeSlider"
                                             :style="{
                                                 opacity: showMoreOptions[avaInfo.sessionId.stringify()] ? 1 : 0,
                                                 transition: showMoreOptions[avaInfo.sessionId.stringify()]

--- a/src/modules/avatar/StoreInterface.ts
+++ b/src/modules/avatar/StoreInterface.ts
@@ -26,7 +26,6 @@ export interface AvatarEntryMap {
 }
 
 function generateID(): string {
-    // eslint-disable-next-line max-len
     const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
     const idLength = 8;
     let ID = "";
@@ -36,19 +35,30 @@ function generateID(): string {
     return ID;
 }
 
-export const AvatarStoreInterface = {
-    getModelData(modelId: string | number, key?: keyof AvatarEntry): AvatarEntry | string | number | boolean {
-        const models = Store.state.avatar.models as { [key: string]: AvatarEntry };
-        if (key && key in (models[modelId] || fallbackAvatar())) {
-            return models[modelId][key];
-        }
-        return models[modelId] || fallbackAvatar();
-    },
+function getModelData(modelId: string | number): AvatarEntry;
+function getModelData<T extends keyof AvatarEntry>(modelId: string | number, key: T): AvatarEntry[T];
+function getModelData<T extends keyof AvatarEntry>(modelId: string | number, key?: T): AvatarEntry | AvatarEntry[T] {
+    const models = Store.state.avatar.models as { [key: string]: AvatarEntry };
+    if (key && key in (models[modelId] || fallbackAvatar())) {
+        return models[modelId][key];
+    }
+    return models[modelId] || fallbackAvatar();
+}
 
-    getActiveModelData(key?: keyof AvatarEntry): AvatarEntry | string | number | boolean {
-        const activeModel = Store.state.avatar.activeModel;
-        return this.getModelData(activeModel, key);
-    },
+function getActiveModelData(): AvatarEntry;
+function getActiveModelData<T extends keyof AvatarEntry>(key: T): AvatarEntry[T];
+function getActiveModelData<T extends keyof AvatarEntry>(key?: T): AvatarEntry | AvatarEntry[T] {
+    const activeModel = Store.state.avatar.activeModel;
+    if (key) {
+        return getModelData(activeModel, key);
+    }
+    return getModelData(activeModel);
+}
+
+export const AvatarStoreInterface = {
+    getModelData,
+
+    getActiveModelData,
 
     getAllModelsJSON(): string {
         return JSON.stringify(Store.state.avatar.models);
@@ -119,13 +129,12 @@ export const AvatarStoreInterface = {
         }
         try {
             const scene = Renderer.getScene();
-            scene.loadMyAvatar(AvatarStoreInterface.getModelData(modelId, "file") as string)
+            scene.loadMyAvatar(AvatarStoreInterface.getModelData(modelId, "file"))
                 // .catch is a syntax error!?
                 // eslint-disable-next-line @typescript-eslint/dot-notation
                 .catch((err) => console.warn("Failed to load avatar:", err));
         } catch (error) {
-            console.warn(error);
-            console.warn("Cannot render active avatar model before the scene has been loaded.");
+            console.warn("Cannot render active avatar model before the scene has been loaded.", error);
         }
     }
 };

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -54,7 +54,7 @@ export class VScene {
     _preScene: Nullable<Scene> = null;
     private _css3DRenderer: Nullable<CSS3DRenderer> = null;
     _myAvatar: Nullable<GameObject> = null;
-    _myAvatarModelURL = AvatarStoreInterface.getActiveModelData("file") as string;
+    _myAvatarModelURL = AvatarStoreInterface.getActiveModelData("file");
 
     _avatarList : Map<string, GameObject>;
     _avatarIsLoading = false;


### PR DESCRIPTION
The old design was focused around the volume slider and mute button, requiring an extra click to access the majority of actions. This was a little backwards, clunky, and made the list items super thick:
![image](https://user-images.githubusercontent.com/22832983/225554298-8bd1e437-cd86-47d1-94e9-4533205fb5db.png)

In the new design the controls take precedence, providing quick access to the majority of actions. The volume slider becomes accessible via a dedicated volume button. The volume button's icon provides an indication of the current volume setting at a glance:
![image](https://user-images.githubusercontent.com/22832983/225783790-c13e0548-dd30-46a9-b014-1ba8771ebd48.png)


Closes #117.