### PR TITLE
Rotate the player's avatar to face forwards when in FPV. Add a state to keep track of the player's interactions.

### DIFF
--- a/src/modules/avatar/controller/inputController.ts
+++ b/src/modules/avatar/controller/inputController.ts
@@ -29,7 +29,7 @@ import { InputState, CameraMode } from "./inputState";
 import { IInputHandler } from "./inputs/inputHandler";
 import { KeyboardInput } from "./inputs/keyboardInput";
 import { VirtualJoystickInput } from "./inputs/virtualJoystickInput";
-import { Store } from "@Store/index";
+import { Store, Mutations as StoreMutations } from "@Store/index";
 import type { SceneController } from "@Modules/scene/controllers";
 import { MouseSettingsController } from "@Base/modules/avatar/controller/inputs/mouseSettings";
 
@@ -422,6 +422,10 @@ export class InputController extends ScriptComponent {
     }
 
     private _updateAvatar(delta : number) {
+        Store.commit(StoreMutations.MUTATE, {
+            property: "interactions.isInteracting",
+            value: false
+        });
         switch (this._avatarState.state) {
             case State.Idle:
                 this._doIdle(delta);
@@ -484,6 +488,10 @@ export class InputController extends ScriptComponent {
     }
 
     private _doPose(delta : number) {
+        Store.commit(StoreMutations.MUTATE, {
+            property: "interactions.isInteracting",
+            value: true
+        });
         this._avatarState.duration += delta;
         if (this._avatarState.duration > 0.5) {
             if (this._avatarState.moveDir.x === 0 && this._avatarState.moveDir.z === 0) {

--- a/src/modules/avatar/controller/inputController.ts
+++ b/src/modules/avatar/controller/inputController.ts
@@ -521,6 +521,17 @@ export class InputController extends ScriptComponent {
             this._gameObject.rotationQuaternion.x = 0;
             this._gameObject.rotationQuaternion.z = 0;
         }
+
+        // Rotate the avatar to follow the yaw direction of the camera.
+        if (this._camera && this._gameObject && this._inputState.cameraMode === CameraMode.FirstPersion) {
+            const angle = Vector3.GetAngleBetweenVectors(
+                this._avatarState.moveDir.normalize(),
+                Vector3.Forward(true),
+                Vector3.Up()
+            );
+            const rotation = this._defaultCameraAlpha + angle - this._camera.alpha + Math.PI / 2;
+            Quaternion.FromEulerAnglesToRef(0, rotation, 0, this._gameObject.rotationQuaternion as Quaternion);
+        }
     }
 
     private _doJump(delta : number) {
@@ -650,7 +661,10 @@ export class InputController extends ScriptComponent {
 
         // Rotate the avatar relative to the yaw direction of the camera.
         const angle = Vector3.GetAngleBetweenVectors(
-            this._avatarState.moveDir.normalize(), Vector3.Forward(true), Vector3.Up());
+            this._avatarState.moveDir.normalize(),
+            Vector3.Forward(true),
+            Vector3.Up()
+        );
         const rotation = this._defaultCameraAlpha + angle - this._camera.alpha;
         Quaternion.FromEulerAnglesToRef(0, rotation, 0, this._gameObject.rotationQuaternion as Quaternion);
 

--- a/src/modules/avatar/controller/inputController.ts
+++ b/src/modules/avatar/controller/inputController.ts
@@ -166,7 +166,7 @@ class ArcRotateCameraCustomInput implements ICameraInput<ArcRotateCamera> {
 class CameraObtacleDetectInfo {
     direction = Vector3.Zero();
     length = 0;
-    isCameraSanpping = false;
+    isCameraSnapping = false;
     elapse = 0;
     detectDuration = 0.5;
 }
@@ -782,12 +782,12 @@ export class InputController extends ScriptComponent {
 
             const pickInfo = this._scene.pickWithRay(ray);
             if (pickInfo && pickInfo.hit && pickInfo.pickedPoint) {
-                if (!this._cameraObtacleDetectInfo.isCameraSanpping) {
+                if (!this._cameraObtacleDetectInfo.isCameraSnapping) {
                     // store camera state before camera is snapped
                     this._camera.storeState();
                     this._cameraObtacleDetectInfo.length = length;
                     this._cameraObtacleDetectInfo.direction = dir;
-                    this._cameraObtacleDetectInfo.isCameraSanpping = true;
+                    this._cameraObtacleDetectInfo.isCameraSnapping = true;
                 }
 
                 if (this._camera.checkCollisions) {
@@ -802,7 +802,7 @@ export class InputController extends ScriptComponent {
             }
         }
 
-        if (!isCameraObstructed && this._cameraObtacleDetectInfo.isCameraSanpping) {
+        if (!isCameraObstructed && this._cameraObtacleDetectInfo.isCameraSnapping) {
             // detect whether camera original position still obstructed or not
             const pickInfo = this._scene.pickWithRay(new Ray(this._camera.target,
                 this._cameraObtacleDetectInfo.direction,
@@ -821,7 +821,7 @@ export class InputController extends ScriptComponent {
                 }
 
                 const vec = this._cameraObtacleDetectInfo.direction.scale(this._cameraObtacleDetectInfo.length);
-                this._cameraObtacleDetectInfo.isCameraSanpping = false;
+                this._cameraObtacleDetectInfo.isCameraSnapping = false;
             }
         }
     }

--- a/src/modules/avatar/controller/inputs/keyboardInput.ts
+++ b/src/modules/avatar/controller/inputs/keyboardInput.ts
@@ -173,8 +173,6 @@ export class KeyboardInput implements IInputHandler {
 
         // Sit.
         if (evt.sourceEvent.code === Store.state.controls.keyboard.movement.sit?.keybind) {
-            const sitDistanceLimit = 1.5;
-
             // Get the player's avatar mesh.
             const avatarMesh = this._scene.meshes.find((mesh) => mesh.name === "MyAvatar");
 
@@ -193,7 +191,7 @@ export class KeyboardInput implements IInputHandler {
                     const distance = object.getAbsolutePosition()
                         .subtract(avatarAbsolutePosition)
                         .length();
-                    if (distance <= sitDistanceLimit) {
+                    if (distance <= Store.state.interactions.interactionDistance) {
                         distances.push([object, distance]);
                     }
                 });

--- a/src/modules/entity/components/components/model.ts
+++ b/src/modules/entity/components/components/model.ts
@@ -19,6 +19,7 @@ import { IModelEntity } from "../../EntityInterfaces";
 import { ShapeType } from "../../EntityProperties";
 import { NametagEntity } from "@Modules/entity/entities";
 import { updateContentLoadingProgress } from "@Modules/scene/LoadingScreen";
+import { Store } from "@Store/index";
 import Log from "@Modules/debugging/log";
 
 const InteractiveModelTypes = [
@@ -69,7 +70,7 @@ export class ModelComponent extends MeshComponent {
                 // Add a nametag to any of the model's children if they match any of the InteractiveModelTypes.
                 const defaultNametagHeight = 0.6;
                 const nametagOffset = 0.25;
-                const nametagPopDistance = 2.5;
+                const nametagPopDistance = Store.state.interactions.interactionDistance;
                 const childNodes = this.mesh.getChildren(
                     (node) => "getBoundingInfo" in node,
                     false

--- a/src/modules/entity/components/components/model.ts
+++ b/src/modules/entity/components/components/model.ts
@@ -88,7 +88,8 @@ export class ModelComponent extends MeshComponent {
                         genericModelType.name,
                         true,
                         undefined,
-                        nametagPopDistance
+                        nametagPopDistance,
+                        () => !Store.state.interactions.isInteracting
                     );
                 });
                 result.transformNodes.forEach((childNode) => {
@@ -102,7 +103,8 @@ export class ModelComponent extends MeshComponent {
                         genericModelType.name,
                         true,
                         undefined,
-                        nametagPopDistance
+                        nametagPopDistance,
+                        () => !Store.state.interactions.isInteracting
                     );
                 });
 
@@ -115,7 +117,8 @@ export class ModelComponent extends MeshComponent {
                         genericModelType.name,
                         true,
                         undefined,
-                        nametagPopDistance
+                        nametagPopDistance,
+                        () => !Store.state.interactions.isInteracting
                     );
                 }
 

--- a/src/modules/entity/components/components/model.ts
+++ b/src/modules/entity/components/components/model.ts
@@ -85,9 +85,9 @@ export class ModelComponent extends MeshComponent {
                         childNode,
                         height + nametagOffset,
                         genericModelType.name,
+                        true,
                         undefined,
-                        nametagPopDistance,
-                        true
+                        nametagPopDistance
                     );
                 });
                 result.transformNodes.forEach((childNode) => {
@@ -99,9 +99,9 @@ export class ModelComponent extends MeshComponent {
                         childNode,
                         defaultNametagHeight,
                         genericModelType.name,
+                        true,
                         undefined,
-                        nametagPopDistance,
-                        true
+                        nametagPopDistance
                     );
                 });
 
@@ -112,9 +112,9 @@ export class ModelComponent extends MeshComponent {
                         this.mesh,
                         defaultNametagHeight,
                         genericModelType.name,
+                        true,
                         undefined,
-                        nametagPopDistance,
-                        true
+                        nametagPopDistance
                     );
                 }
 

--- a/src/modules/entity/entities/NametagEntity.ts
+++ b/src/modules/entity/entities/NametagEntity.ts
@@ -100,6 +100,9 @@ export class NametagEntity {
      * @param icon Display the name as an icon instead of text.
      * @param color The color of the nametag's background.
      * @param popDistance The distance from the player's avatar at which the nametag will stop being visible.
+     * @param popOverride A function overriding the visibility of the nametag.
+     * This function receives the distance from the player's avatar to the nametag,
+     * and should return a boolean indicating whether the nametag should be visible (`true`) or not (`false`).
      * @returns A reference to the new nametag mesh.
      */
     public static create(
@@ -108,7 +111,8 @@ export class NametagEntity {
         name: string,
         icon = false,
         color?: Color3,
-        popDistance = 20
+        popDistance = 20,
+        popOverride?: ((distance: number) => boolean)
     ): Mesh | undefined {
         const scene = object.getScene();
         const font = icon ? this.iconFont : this.textFont;
@@ -274,7 +278,9 @@ export class NametagEntity {
                 // Clamp the opacity between 0 and 0.94.
                 // Max opacity of 0.94 reduces the chance that the nametag will be affected by bloom.
                 const opacity = Math.min(Math.max(popDistance + 1 - distance, 0), 0.94);
-                nametagMergedMesh.visibility = opacity * Number(Store.state.avatar.showNametags);
+                nametagMergedMesh.visibility = opacity * Number(
+                    Store.state.avatar.showNametags && (popOverride?.(distance) ?? true)
+                );
             }
         });
 

--- a/src/modules/entity/entities/NametagEntity.ts
+++ b/src/modules/entity/entities/NametagEntity.ts
@@ -97,18 +97,18 @@ export class NametagEntity {
      * @param object The mesh/transform node to attach the nametag to.
      * @param height The height of the object (the nametag will be positioned above this point).
      * @param name The name to be displayed on the nametag.
-     * @param color The color of the nametag's background.
-     * @param popDistance The distance from the active camera at which the nametag will stop being visible.
      * @param icon Display the name as an icon instead of text.
+     * @param color The color of the nametag's background.
+     * @param popDistance The distance from the player's avatar at which the nametag will stop being visible.
      * @returns A reference to the new nametag mesh.
      */
     public static create(
         object: Mesh | AbstractMesh | TransformNode,
         height: number,
         name: string,
+        icon = false,
         color?: Color3,
-        popDistance = 20,
-        icon = false
+        popDistance = 20
     ): Mesh | undefined {
         const scene = object.getScene();
         const font = icon ? this.iconFont : this.textFont;

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -397,6 +397,7 @@ export class VScene {
                 this._myAvatar,
                 avatarHeight,
                 Store.state.avatar.displayName,
+                false,
                 nametagColor
             );
             // Update the nametag color when the player's admin state is changed in the Store.
@@ -404,14 +405,14 @@ export class VScene {
                 nametagColor = value ? Color3.FromHexString(Store.state.theme.colors.primary) : undefined;
                 NametagEntity.removeAll(this._myAvatar);
                 if (this._myAvatar) {
-                    NametagEntity.create(this._myAvatar, avatarHeight, Store.state.avatar.displayName, nametagColor);
+                    NametagEntity.create(this._myAvatar, avatarHeight, Store.state.avatar.displayName, false, nametagColor);
                 }
             });
             // Update the nametag when the displayName is changed in the Store.
             Store.watch((state) => state.avatar.displayName, (value: string) => {
                 NametagEntity.removeAll(this._myAvatar);
                 if (this._myAvatar) {
-                    NametagEntity.create(this._myAvatar, avatarHeight, value, nametagColor);
+                    NametagEntity.create(this._myAvatar, avatarHeight, value, false, nametagColor);
                 }
             });
 
@@ -467,14 +468,14 @@ export class VScene {
             let nametagColor = Store.state.avatars.avatarsInfo.get(id)?.isAdmin
                 ? Color3.FromHexString(Store.state.theme.colors.primary)
                 : undefined;
-            NametagEntity.create(avatar, avatarHeight, domain.displayName, nametagColor);
+            NametagEntity.create(avatar, avatarHeight, domain.displayName, false, nametagColor);
             // Update the nametag color when the player's admin state is changed.
             Store.watch((state) => Boolean(state.avatars.avatarsInfo.get(id)?.isAdmin), (value: boolean) => {
                 nametagColor = value ? Color3.FromHexString(Store.state.theme.colors.primary) : undefined;
                 const nametagAvatar = this._avatarList.get(stringId);
                 NametagEntity.removeAll(nametagAvatar);
                 if (nametagAvatar) {
-                    NametagEntity.create(nametagAvatar, avatarHeight, domain.displayName, nametagColor);
+                    NametagEntity.create(nametagAvatar, avatarHeight, domain.displayName, false, nametagColor);
                 }
             });
             // Update the nametag when the displayName is changed.
@@ -482,7 +483,7 @@ export class VScene {
                 const nametagAvatar = this._avatarList.get(stringId);
                 NametagEntity.removeAll(nametagAvatar);
                 if (nametagAvatar) {
-                    NametagEntity.create(nametagAvatar, avatarHeight, domain.displayName, nametagColor);
+                    NametagEntity.create(nametagAvatar, avatarHeight, domain.displayName, false, nametagColor);
                 }
             });
         }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -383,7 +383,7 @@ export interface IRootState {
     bookmarks: {
         locations: { name: string, color: string, url: string }[]
     },
-    // Control keybinds.
+    // Controls.
     controls: {
         keyboard: {
             movement: {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -404,6 +404,11 @@ export interface IRootState {
             invert: boolean,
             sensitivity: number
         }
+    },
+    // State of interactions with the player's avatar.
+    interactions: {
+        interactionDistance: number,
+        isInteracting: boolean
     }
 }
 
@@ -594,6 +599,11 @@ const storeDefaults = {
             invert: false,
             sensitivity: 50
         }
+    },
+    // State of interactions with the player's avatar.
+    interactions: {
+        interactionDistance: 1.5,
+        isInteracting: false
     }
 } as IRootState;
 


### PR DESCRIPTION
The PR contains two unrelated changes (oops).
1. When in first-person view, rotate the player's avatar so that it faces the same direction that they are looking.
2. Add a state to keep track of the player's interactions (relates to #143).