### PR TITLE
Fix silent audio input/output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ node_modules
 .quasar
 /dist
 
+# Web workers copied from dependencies.
+/public/js
+
 # Cordova related directories and files
 /src-cordova/node_modules
 /src-cordova/platforms

--- a/build_scripts/copyWorkers.mjs
+++ b/build_scripts/copyWorkers.mjs
@@ -1,0 +1,38 @@
+//
+//  copyWorkers.js
+//
+//  Copy web-worker scripts from the Web SDK to the application.
+//  This is for static scripts that cannot be included by `import` or `require`.
+//
+//  Created by Giga on 18 September 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import { copyFileSync, existsSync, mkdirSync } from "fs";
+
+// The workers to copy.
+const workers = [
+    "vircadia-audio-input.js",
+    "vircadia-audio-input.js.map",
+    "vircadia-audio-output.js",
+    "vircadia-audio-output.js.map"
+];
+// The destination for the worker files.
+const destination = "public/js/";
+
+// Ensure the destination exists.
+if (!existsSync(destination)) {
+    mkdirSync(destination, { recursive: true });
+}
+
+// Copy the worker files to the destination.
+console.log("Copying workers...");
+for (const worker of workers) {
+    copyFileSync(`node_modules/@vircadia/web-sdk/dist/${worker}`, `${destination}${worker}`);
+    console.log("  »\x1b[32m", worker, "\x1b[0m");
+}
+console.log("Done.\n");

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "author": "DigiSomni LLC | Vircadia Contributors",
   "license": "Apache-2.0",
   "scripts": {
-    "build": "npm run create-version && npm run build-quasar",
-    "dev": "npm run create-version && npm run build-quasar-dev",
+    "build": "npm run create-version && npm run copy-workers && npm run build-quasar",
+    "dev": "npm run create-version && npm run copy-workers && npm run build-quasar-dev",
     "build-quasar": "quasar build",
     "build-quasar-dev": "quasar dev",
     "lint": "eslint --ext .js,.ts,.vue ./",
     "create-version": "node build_scripts/createVersion.js",
+    "copy-workers": "node build_scripts/copyWorkers.mjs",
     "update-contributors": "git-authors-cli"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes a regression introduced by #175 that prevented the Web SDK's audio workers from being included in the application build. This resulted in no audio data being sent to / received from the Domain server.

This PR adds a [new build script](https://github.com/vircadia/vircadia-web/blob/d731e26d4ebc0eabe1cd3cd39ddd8de3f5ddc14d/build_scripts/copyWorkers.mjs) that copies the required audio workers into the application before it's built. This script can also be run manually with:
```
npm run copy-workers
```