### PR TITLE
Add loading screen hint messages.

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -102,6 +102,7 @@ module.exports = configure(function(ctx) {
                 VRCA_BANNER_ALT: process.env.VRCA_BANNER_ALT ?? packageJSON.productName,
                 VRCA_GLOBAL_SERVICE_TERM: process.env.VRCA_GLOBAL_SERVICE_TERM ?? "Metaverse",
                 VRCA_VERSION_WATERMARK: process.env.VRCA_VERSION_WATERMARK ?? "Early Developer Alpha",
+                VRCA_SHOW_LOADING_SCREEN_HINTS: process.env.VRCA_SHOW_LOADING_SCREEN_HINTS ?? "true",
                 // Theme > Colors
                 VRCA_COLORS_PRIMARY: process.env.VRCA_COLORS_PRIMARY ?? "#0c71c3",
                 VRCA_COLORS_SECONDARY: process.env.VRCA_COLORS_SECONDARY ?? "#8300e9",

--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -104,7 +104,11 @@
                 size="xl"
             />
         </div>
-        <div class="hint" :class="{ showNext }">
+        <div
+            v-if="applicationStore.theme.showLoadingScreenHints !== 'false'"
+            class="hint"
+            :class="{ showNext }"
+        >
             <div v-html="hint"></div>
             <div v-html="nextHint"></div>
         </div>
@@ -164,7 +168,10 @@ export default defineComponent({
                 index.value = wrap(index.value += 1);
             }, transition);
         }
-        window.setInterval(changeHint, delay);
+
+        if (applicationStore.theme.showLoadingScreenHints.toLowerCase() !== "false") {
+            window.setInterval(changeHint, delay);
+        }
 
         return {
             applicationStore,

--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -18,7 +18,7 @@
     flex-flow: column nowrap;
     justify-content: center;
     align-items: center;
-    gap: 10px;
+    gap: 6rem;
     background-color: #000;
     user-select: none;
 
@@ -43,6 +43,53 @@
         position: absolute;
         transform: scale(5);
     }
+
+    .hint {
+        --transition-duration: 0.8s;
+        position: relative;
+        display: flex;
+        flex-flow: column nowrap;
+        justify-content: center;
+        align-items: center;
+        gap: 0;
+        width: 100%;
+        padding: 0 2rem;
+        font-size: 1em;
+        line-height: 1.7em;
+        text-align: center;
+
+        & > div {
+            position: absolute;
+            padding: 0 2rem;
+        }
+
+        & > div::before {
+            content: 'Hint: ';
+            opacity: 0.8;
+        }
+
+        & > div:nth-child(1) {
+            transform: translateY(0);
+            opacity: 1;
+        }
+
+        & > div:nth-child(2) {
+            transform: translateY(100%);
+            opacity: 0;
+        }
+
+        &.showNext > div:nth-child(1) {
+            transform: translateY(-100%);
+            opacity: 0;
+            transition: var(--transition-duration) ease-out transform, var(--transition-duration) ease-out opacity;
+        }
+
+        &.showNext > div:nth-child(2) {
+            transform: translateY(0);
+            opacity: 1;
+            transition: var(--transition-duration) ease-out transform, var(--transition-duration) ease-out opacity;
+        }
+    }
 }
 </style>
 
@@ -57,19 +104,73 @@
                 size="xl"
             />
         </div>
+        <div class="hint" :class="{ showNext }">
+            <div v-html="hint"></div>
+            <div v-html="nextHint"></div>
+        </div>
     </div>
 </template>
 
 <script lang="ts">
-import { defineComponent } from "vue";
-import { applicationStore } from "@Stores/index";
+import { computed, defineComponent, ref } from "vue";
+import { KeyboardSettings } from "@Modules/avatar/controller/inputs/keyboardSettings";
+import { applicationStore, userStore } from "@Stores/index";
 
 export default defineComponent({
     name: "LoadingScreen",
 
     setup() {
+        /* eslint-disable max-len */
+        /**
+         * The list of hint messages. Add/remove messages from this list.
+         */
+        const hints = [
+            `Press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.movement.fly.keycode)}</kbd> to fly.`,
+            `If you get stuck somewhere, press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.other.resetPosition.keycode)}</kbd> to reset your position.`,
+            `The "People" menu shows you everyone else present in your world.`,
+            `Almonds are a member of the peach family.`,
+            `You can press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.other.openChat.keycode)}</kbd> to quickly open the chat.`,
+            `Sloths can hold their breath longer than dolphins.`,
+            `Press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.movement.clap.keycode)}</kbd> to clap.`,
+            `Australia is wider than the moon.`,
+            `Press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.movement.salute.keycode)}</kbd> to salute.`,
+            `Vircadia supports 400+ people connected to the same world at once!`,
+            `Press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.movement.sit.keycode)}</kbd> to sit down anywhere.`,
+            `You can change your avatar and display name in the "Avatar" menu.`,
+            `You are amazing!`
+        ];
+        /* eslint-enable max-len */
+
+        /**
+         * Wrap an index to the range 0 -> hints.length - 1.
+         * @param index The index to wrap.
+         * @returns The wrapped index.
+         */
+        function wrap(index: number): number {
+            return Math.max(index > hints.length - 1 ? 0 : index, 0);
+        }
+
+        const index = ref(Math.floor(Math.random() * hints.length));
+        const hint = computed(() => hints[index.value]);
+        const nextHint = computed(() => hints[wrap(index.value + 1)]);
+        const delay = 9000;
+        const transition = 1000;
+        const showNext = ref(false);
+
+        function changeHint(): void {
+            showNext.value = true;
+            window.setTimeout(() => {
+                showNext.value = false;
+                index.value = wrap(index.value += 1);
+            }, transition);
+        }
+        window.setInterval(changeHint, delay);
+
         return {
-            applicationStore
+            applicationStore,
+            hint,
+            nextHint,
+            showNext
         };
     }
 });

--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -23,7 +23,7 @@
     background-color: #000;
     user-select: none;
 
-    & > .inner {
+    &>.inner {
         display: flex;
         flex-flow: column nowrap;
         justify-content: center;
@@ -59,33 +59,33 @@
         line-height: 1.7em;
         text-align: center;
 
-        & > div {
+        &>div {
             position: absolute;
             padding: 0 2rem;
         }
 
-        & > div::before {
+        &>div::before {
             content: 'Hint: ';
             opacity: 0.8;
         }
 
-        & > div:nth-child(1) {
+        &>div:nth-child(1) {
             transform: translateY(0);
             opacity: 1;
         }
 
-        & > div:nth-child(2) {
+        &>div:nth-child(2) {
             transform: translateY(100%);
             opacity: 0;
         }
 
-        &.showNext > div:nth-child(1) {
+        &.showNext>div:nth-child(1) {
             transform: translateY(-100%);
             opacity: 0;
             transition: var(--transition-duration) ease-out transform, var(--transition-duration) ease-out opacity;
         }
 
-        &.showNext > div:nth-child(2) {
+        &.showNext>div:nth-child(2) {
             transform: translateY(0);
             opacity: 1;
             transition: var(--transition-duration) ease-out transform, var(--transition-duration) ease-out opacity;
@@ -95,21 +95,12 @@
 </style>
 
 <template>
-    <div
-        id="loadingScreen"
-        @click.stop=""
-    >
+    <div id="loadingScreen" @click.stop="">
         <div class="inner">
             <img :src="applicationStore.theme.logo" draggable="false" alt="" width="200" height="200">
-            <q-spinner-tail
-                size="xl"
-            />
+            <q-spinner-tail size="xl" />
         </div>
-        <div
-            v-if="applicationStore.theme.showLoadingScreenHints !== 'false'"
-            class="hint"
-            :class="{ showNext }"
-        >
+        <div v-if="applicationStore.theme.showLoadingScreenHints !== 'false'" class="hint" :class="{ showNext }">
             <div v-html="hint"></div>
             <div v-html="nextHint"></div>
         </div>
@@ -127,7 +118,7 @@ export default defineComponent({
     setup() {
         /* eslint-disable max-len */
         /**
-         * The list of hint messages. Add/remove messages from this list.
+         * The list of hint messages. Add/remove messages from this list. TODO: Add ability to load list of strings from env variable and format them on load.
          */
         const hints = [
             `Press <kbd>${KeyboardSettings.formatKeyName(userStore.controls.keyboard.movement.fly.keycode)}</kbd> to fly.`,

--- a/src/components/LoadingScreen.vue
+++ b/src/components/LoadingScreen.vue
@@ -19,6 +19,7 @@
     justify-content: center;
     align-items: center;
     gap: 6rem;
+    color: white;
     background-color: #000;
     user-select: none;
 

--- a/src/components/overlays/settings/Controls.vue
+++ b/src/components/overlays/settings/Controls.vue
@@ -14,23 +14,6 @@
     padding: 2px 1ch;
     border: 2px dashed currentColor;
 }
-kbd {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: fit-content;
-    min-width: 3.5ch;
-    padding: 2px 1ch;
-    color: white;
-    font-family: inherit;
-    font-size: 1.0rem;
-    text-align: center;
-    background: radial-gradient(circle at center, #888 20%, #556);
-    background-position: center;
-    background-size: 170%;
-    border-radius: 5px;
-    box-shadow: 0px 3px 0px #444;
-}
 </style>
 
 <template>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -32,3 +32,21 @@ h2,
 h3 {
     font-family: 'Cairo', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif !important;
 }
+
+kbd {
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: fit-content;
+    min-width: 3ch;
+    padding: 1px 0.5ch;
+    color: white;
+    font-family: inherit;
+    font-size: 1.0rem;
+    text-align: center;
+    background: radial-gradient(circle at center, #888 20%, #556);
+    background-position: center;
+    background-size: 170%;
+    border-radius: 5px;
+    box-shadow: 0px 3px 0px #444;
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -8,6 +8,7 @@ declare namespace NodeJS {
         VRCA_DEFAULT_DOMAIN_PORT: string;
         VRCA_DEFAULT_DOMAIN_URL: string;
         VRCA_GLOBAL_SERVICE_TERM: string;
+        VRCA_SHOW_LOADING_SCREEN_HINTS: "true" | "false";
         // Theme -> Styles
         VRCA_DEFAULT_MODE: "light" | "dark";
         VRCA_GLOBAL_STYLE: "none" | "aero" | "mica";

--- a/src/stores/application-store.ts
+++ b/src/stores/application-store.ts
@@ -129,6 +129,7 @@ export const useApplicationStore = defineStore("application", {
             url: process.env.VRCA_HOSTED_URL,
             globalServiceTerm: process.env.VRCA_GLOBAL_SERVICE_TERM,
             versionWatermark: process.env.VRCA_VERSION_WATERMARK,
+            showLoadingScreenHints: process.env.VRCA_SHOW_LOADING_SCREEN_HINTS,
             colors: {
                 primary: process.env.VRCA_COLORS_PRIMARY,
                 secondary: process.env.VRCA_COLORS_SECONDARY,


### PR DESCRIPTION
This PR adds hints to the loading screen, similar to other games:
![image](https://github.com/vircadia/vircadia-web/assets/22832983/82fe7855-a128-4e9b-9db8-df5190642808)

This feature is enabled by default, and can be disabled by setting the `VRCA_SHOW_LOADING_SCREEN_HINTS` environment variable to `"false"`.

The list of hint messages can be changed in the [src/components/LoadingScreen.vue](../blob/master/src/components/LoadingScreen.vue) component.