### PR TITLE
Alternate sit mechanism

### DIFF
--- a/src/modules/avatar/controller/InteractionController.ts
+++ b/src/modules/avatar/controller/InteractionController.ts
@@ -1,0 +1,353 @@
+//
+//  InteractionController.ts
+//
+//  This controller handles the interactions between the local avatar
+//  and interaction targets (previously referred to as animatables or sit-objects).
+//
+//  Created by Giga on 27 Oct 2023.
+//  Copyright 2023 Vircadia contributors.
+//  Copyright 2023 DigiSomni LLC.
+//
+//  Distributed under the Apache License, Version 2.0.
+//  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
+//
+
+import {
+    type AbstractMesh,
+    Color3,
+    type InstancedMesh,
+    type Mesh,
+    type Node,
+    type TransformNode,
+    Vector3
+} from "@babylonjs/core";
+import { ScriptComponent } from "@Modules/script";
+import { Renderer, VScene } from "@Modules/scene";
+import { applicationStore } from "@Stores/index";
+import { LabelEntity } from "@Modules/entity/entities";
+
+export const InteractiveModelTypes = [
+    { name: "chair", condition: /^(?:animate_sitting|animate_seat)/iu },
+    { name: "emoji_people", condition: /^animate_/iu }
+] as const;
+
+export class InteractionTarget {
+    animation = "";
+    private _color = Color3.Black();
+    private _exitPosition = Vector3.Zero();
+    private _icon = "";
+    private _label: Nullable<Mesh>;
+    private _parent: AbstractMesh | Mesh | TransformNode;
+    private _popDistance = 0;
+    private _position = Vector3.Zero();
+    private _rotation = Vector3.Zero();
+    private _text = "";
+
+    constructor(parent: AbstractMesh | Mesh | TransformNode) {
+        this._parent = parent;
+        this._remakeLabel();
+    }
+
+    /**
+     * The color of the interaction target's label.
+     */
+    get color(): Color3 {
+        return this._color;
+    }
+
+    set color(value: string | Color3) {
+        if (typeof value === "string") {
+            this._color = Color3.FromHexString(value);
+        } else {
+            this._color = value;
+        }
+        this._remakeLabel();
+    }
+
+    /**
+     * The position the avatar should snap to when the interaction has finished.
+     * (Relative to the interaction target).
+     */
+    get exitPosition(): Vector3 {
+        return this._exitPosition;
+    }
+
+    set exitPosition(value: string | Vector3) {
+        this._exitPosition = InteractionTarget._parseVector3(value);
+    }
+
+    /**
+     * The absolute position of the interaction target in the world.
+     */
+    get absolutePosition(): Vector3 {
+        return this._parent.getAbsolutePosition().add(this._position);
+    }
+
+    /**
+     * The icon to show on the interaction target's label.
+     */
+    get icon(): string {
+        return this._icon;
+    }
+
+    set icon(value: string) {
+        this._icon = value;
+        this._remakeLabel();
+    }
+
+    /**
+     * This distance from the interaction target at which its label should fade out.
+     */
+    get popDistance(): number {
+        return this._popDistance;
+    }
+
+    set popDistance(value: number) {
+        this._popDistance = value;
+        this._remakeLabel();
+    }
+
+    /**
+     * The position of the interaction target relative to its parent object.
+     * (The avatar will be snapped to this position while interacting).
+     */
+    get position(): Vector3 {
+        return this._position;
+    }
+
+    set position(value: string | Vector3) {
+        this._position = InteractionTarget._parseVector3(value);
+        this._remakeLabel();
+    }
+
+    /**
+     * The rotation of the interaction target relative to its parent object.
+     * (The avatar will be snapped to this rotation while interacting).
+     */
+    get rotation(): Vector3 {
+        return this._rotation;
+    }
+
+    set rotation(value: string | Vector3) {
+        const rotation = InteractionTarget._parseVector3(value);
+        // Convert from degrees to radians.
+        rotation.x = rotation.x * Math.PI / 180;
+        rotation.y = rotation.y * Math.PI / 180;
+        rotation.z = rotation.z * Math.PI / 180;
+        this._rotation = rotation;
+    }
+
+    /**
+     * The text to show on the interaction target's label.
+     */
+    get text(): string {
+        return this._text;
+    }
+
+    set text(value: string) {
+        this._text = value;
+        this._remakeLabel();
+    }
+
+    private _remakeLabel(): void {
+        LabelEntity.remove(this._label);
+        this._label = LabelEntity.create(
+            this._parent,
+            0,
+            this._icon || this._text,
+            Boolean(this._icon),
+            this._color,
+            this._popDistance
+        );
+        if (this._label) {
+            this._label.position = this._position;
+        }
+    }
+
+    private static _parseVector3(vector: string | Vector3): Vector3 {
+        if (typeof vector === "string") {
+            const output = Vector3.Zero();
+            if (!vector || typeof vector !== "string") {
+                return output;
+            }
+            const parsedString = (/^(?<x>[\d.-]+)[,\s]+(?<y>[\d.-]+)[,\s]+(?<z>[\d.-]+)/iu).exec(vector);
+            if (!parsedString?.groups?.x || !parsedString?.groups?.y || !parsedString?.groups?.z) {
+                return output;
+            }
+            output.x = parseFloat(parsedString.groups.x);
+            output.y = parseFloat(parsedString.groups.y);
+            output.z = parseFloat(parsedString.groups.z);
+            return output;
+        }
+        return vector.clone();
+    }
+
+    /**
+     * Create a new set of interaction targets based on the metadata properties of a given mesh.
+     * @param mesh The mesh to read the metadata from.
+     * @returns An array of interaction targets.
+     */
+    public static fromMesh(mesh: AbstractMesh | Mesh | InstancedMesh | TransformNode): Array<InteractionTarget> {
+        const meshExtras = mesh.metadata?.gltf?.extras as Nullable<Record<string, boolean | number | string>>;
+        const targets = new Array<InteractionTarget>();
+        if (!meshExtras || typeof meshExtras !== "object") {
+            return targets;
+        }
+        for (const [property, value] of Object.entries(meshExtras)) {
+            const parsedProperty = (/^vircadia_sit_(?<index>[\d]+)_(?<type>[\w]+)/iu).exec(property);
+            if (!parsedProperty?.groups?.index || !parsedProperty?.groups?.type) {
+                continue;
+            }
+            const index = parseInt(parsedProperty.groups.index, 10);
+            const type = parsedProperty.groups.type.toLowerCase();
+            if (!targets[index]) {
+                targets[index] = new InteractionTarget(mesh);
+            }
+            switch (type) {
+                case "position":
+                    targets[index].position = this._parseVector3(String(value));
+                    break;
+                case "rotation":
+                    targets[index].rotation = this._parseVector3(String(value));
+                    break;
+                case "exit_position":
+                    targets[index].exitPosition = this._parseVector3(String(value));
+                    break;
+                case "icon":
+                    targets[index].icon = String(value);
+                    break;
+                case "text":
+                    targets[index].text = String(value);
+                    break;
+                case "color":
+                    targets[index].color = String(value);
+                    break;
+                case "label_distance":
+                    targets[index].popDistance = typeof value === "string" ? parseFloat(value) : Number(value);
+                    break;
+                case "animation":
+                    targets[index].animation = String(value);
+                    break;
+                default:
+                    break;
+            }
+        }
+        return targets;
+    }
+}
+
+export class InteractionController extends ScriptComponent {
+    private _vscene: VScene;
+
+    constructor(vscene: VScene) {
+        super(InteractionController.typeName);
+        this._vscene = vscene;
+    }
+
+    /**
+     * A string identifying the type of this component.
+     * @returns "InteractionController"
+     */
+    public get componentType(): string {
+        return InteractionController.typeName;
+    }
+
+    static get typeName(): string {
+        return "InteractionController";
+    }
+
+    /**
+     * Register an interaction target with the scene.
+     * The scene keeps a reference to the target, so any changes to the original target will be reflected in the scene.
+     * @param target The target to register.
+     */
+    public addTarget(target: InteractionTarget): void {
+        applicationStore.interactions.targets.push(target);
+    }
+
+    /**
+     * Register multiple interaction targets with the scene.
+     * The scene keeps references to the targets, so any changes to the original targets will be reflected in the scene.
+     * @param targets The targets to register.
+     */
+    public addTargets(targets: Array<InteractionTarget>): void {
+        for (const target of targets) {
+            applicationStore.interactions.targets.push(target);
+        }
+    }
+
+    /**
+     * Remove an interaction target from the scene.
+     * @param target The target to remove.
+     */
+    public removeTarget(target: InteractionTarget): void {
+        const index = applicationStore.interactions.targets.indexOf(target);
+        applicationStore.interactions.targets.splice(index, 1);
+    }
+
+    /**
+     * Remove multiple interaction targets from the scene.
+     * @param target The targets to remove.
+     */
+    public removeTargets(targets: Array<InteractionTarget>): void {
+        for (const target of targets) {
+            const index = applicationStore.interactions.targets.indexOf(target);
+            applicationStore.interactions.targets.splice(index, 1);
+        }
+    }
+
+    /**
+     * Retrieve the interaction target that is currently closest to the local avatar.
+     * @returns The closest interaction target, or `undefined` if none was found or was within the max interaction distance.
+     */
+    public getNearestTarget(): Nullable<InteractionTarget> {
+        const avatar = Renderer.getScene().getMyAvatar();
+        const avatarAbsolutePosition = avatar?.getAbsolutePosition();
+        if (!avatarAbsolutePosition) {
+            return undefined;
+        }
+
+        // Filter out any targets that are too far away, or don't have an absolute position.
+        const distances = new Array<[InteractionTarget | TransformNode | AbstractMesh, number]>();
+        // Search through the registered targets.
+        for (const target of applicationStore.interactions.targets) {
+            if (!target) {
+                continue;
+            }
+            if (!(target instanceof InteractionTarget) && !("getAbsolutePosition" in target)) {
+                continue;
+            }
+            const distance = target.absolutePosition
+                .subtract(avatarAbsolutePosition)
+                .length();
+            if (distance <= applicationStore.interactions.interactionDistance) {
+                distances.push([target as InteractionTarget, distance]);
+            }
+        }
+        // Search through the scene.
+        const sceneNodes = this._scene.getNodes() as (Node | TransformNode | AbstractMesh)[];
+        const targetNodes = sceneNodes.filter((node) => (/^animate_/iu).test(node.name));
+        for (const node of targetNodes) {
+            if (!("getAbsolutePosition" in node)) {
+                continue;
+            }
+            const distance = node.getAbsolutePosition()
+                .subtract(avatarAbsolutePosition)
+                .length();
+            if (distance <= applicationStore.interactions.interactionDistance) {
+                distances.push([node, distance]);
+            }
+        }
+
+        // If there are multiple interactive targets in range, use the closest one.
+        if (distances.length > 0) {
+            const closestTarget = distances.reduce((a, b) => (a[1] <= b[1] ? a : b));
+            if (closestTarget[0] instanceof InteractionTarget) {
+                return closestTarget[0];
+            }
+            return InteractionTarget.fromMesh(closestTarget[0])[0];
+        }
+
+        return undefined;
+    }
+}

--- a/src/modules/avatar/index.ts
+++ b/src/modules/avatar/index.ts
@@ -10,6 +10,7 @@
 //
 
 export { InputController } from "./controller/inputController";
+export { InteractionController } from "./controller/InteractionController";
 export { ScriptAvatarController } from "./controller/scriptAvatarController";
 export { MyAvatarController } from "./controller/myAvatarController";
 export { AvatarMapper } from "./AvatarMapper";

--- a/src/modules/entity/EntityProperties.ts
+++ b/src/modules/entity/EntityProperties.ts
@@ -13,20 +13,20 @@ import { WebInputMode } from "@vircadia/web-sdk";
 
 
 export type EntityType =
-"Unknown" | "Box" | "Sphere" | "Shape" | "Model" |
-"Text" | "Image" | "Web" | "ParticleEffect" |
-"Line" | "PolyLine" | "PolyVox" | "Grid" | "Gizmo" |
-"Light" | "Zone" | "Material";
+    "Unknown" | "Box" | "Sphere" | "Shape" | "Model" |
+    "Text" | "Image" | "Web" | "ParticleEffect" |
+    "Line" | "PolyLine" | "PolyVox" | "Grid" | "Gizmo" |
+    "Light" | "Zone" | "Material";
 
 export type Shape =
-"Circle" | "Cone" | "Cube" | "Cylinder" | "Dodecahedron" |
-"Hexagon" | "Icosahedron" | "Octagon" | "Octahedron" |
-"Quad" | "Sphere" | "Tetrahedron" | "Torus" | "Triangle";
+    "Circle" | "Cone" | "Cube" | "Cylinder" | "Dodecahedron" |
+    "Hexagon" | "Icosahedron" | "Octagon" | "Octahedron" |
+    "Quad" | "Sphere" | "Tetrahedron" | "Torus" | "Triangle";
 
 export type ShapeType = "none" | "box" | "sphere" | "cylinder" |
-"capsule-x" | "capsule-y" | "capsule-z" | "cylinder-x" | "cylinder-y" | "cylinder-z" |
-"hull" | "compound" | "simple-hull" | "simple-compound" | "static-mesh" |
-"plane" | "ellipsoid" | "circle" | "multisphere";
+    "capsule-x" | "capsule-y" | "capsule-z" | "cylinder-x" | "cylinder-y" | "cylinder-z" |
+    "hull" | "compound" | "simple-hull" | "simple-compound" | "static-mesh" |
+    "plane" | "ellipsoid" | "circle" | "multisphere";
 
 export type MaterialMappingMode = "uv" | "projected";
 
@@ -74,7 +74,7 @@ export interface IColorProperty {
 
 export interface IAmbientLightProperty {
     ambientIntensity?: number | undefined;
-    ambientURL? : string | undefined;
+    ambientURL?: string | undefined;
 }
 
 export interface IKeyLightProperty {
@@ -88,7 +88,7 @@ export interface IKeyLightProperty {
 
 export interface ISkyboxProperty {
     color: IColorProperty | undefined;
-    url:string | undefined;
+    url: string | undefined;
 }
 
 export interface IHazeProperty {

--- a/src/modules/entity/EntityProperties.ts
+++ b/src/modules/entity/EntityProperties.ts
@@ -9,7 +9,7 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-import { WebInputMode } from "@vircadia/web-sdk";
+import type { WebInputMode } from "@vircadia/web-sdk";
 
 
 export type EntityType =

--- a/src/modules/entity/components/scripts/TeleportController.ts
+++ b/src/modules/entity/components/scripts/TeleportController.ts
@@ -9,8 +9,6 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-/* eslint-disable @typescript-eslint/no-magic-numbers */
-
 import Log from "@Modules/debugging/log";
 import { inspector } from "@Modules/script";
 import { Renderer, VScene } from "@Modules/scene";

--- a/src/modules/entity/index.ts
+++ b/src/modules/entity/index.ts
@@ -9,12 +9,13 @@
 //  See the accompanying file LICENSE or http://www.apache.org/licenses/LICENSE-2.0.html
 //
 
-export type { IEntity, IModelEntity, IShapeEntity, ILightEntity, IZoneEntity,
-    IImageEntity } from "./EntityInterfaces";
-export type { IVector3Property, IQuaternionProperty, IColorProperty,
+export type { IEntity, IModelEntity, IShapeEntity, ILightEntity, IZoneEntity, IImageEntity } from "./EntityInterfaces";
+export type {
+    IVector3Property, IQuaternionProperty, IColorProperty,
     IAmbientLightProperty, IKeyLightProperty, ISkyboxProperty,
     IHazeProperty, IBloomProperty, IGrabProperty,
-    EntityType } from "./EntityProperties";
+    EntityType
+} from "./EntityProperties";
 export type { IEntityDescription } from "./EntityDescription";
 export { EntityBuilder } from "./EntityBuilder";
 export { EntityManager } from "./EntityManager";

--- a/src/modules/scene/vscene.ts
+++ b/src/modules/scene/vscene.ts
@@ -45,10 +45,11 @@ import {
     requireScripts,
 } from "@Modules/script";
 import {
+    AvatarMapper,
     InputController,
+    InteractionController,
     MyAvatarController,
     ScriptAvatarController,
-    AvatarMapper,
 } from "@Modules/avatar";
 import {
     IEntity,
@@ -85,14 +86,12 @@ export class VScene {
     _avatarAnimationGroups: AnimationGroup[] = [];
     _resourceManager: Nullable<ResourceManager> = null;
     _domainController: Nullable<DomainController> = null;
+    _interactionController: Nullable<InteractionController> = null;
     _sceneController: Nullable<SceneController> = null;
     _sceneManager: Nullable<GameObject> = null;
     _currentSceneURL = "";
-    private _onMyAvatarModelChangedObservable: Observable<GameObject> =
-        new Observable<GameObject>();
-
-    private _onEntityEventObservable: Observable<EntityEvent> =
-        new Observable<EntityEvent>();
+    private _onMyAvatarModelChangedObservable = new Observable<GameObject>();
+    private _onEntityEventObservable = new Observable<EntityEvent>();
 
     constructor(pEngine: Engine, pSceneId = 0) {
         if (process.env.NODE_ENV === "development") {
@@ -144,6 +143,10 @@ export class VScene {
 
     public get css3DRenderer(): Nullable<CSS3DRenderer> {
         return this._css3DRenderer;
+    }
+
+    public get interactionController(): Nullable<InteractionController> {
+        return this._interactionController;
     }
 
     public get sceneController(): Nullable<SceneController> {
@@ -262,15 +265,12 @@ export class VScene {
             const positionOffset = avatar.calcMovePOV(0, 0, 1.5);
             const position = avatar.position.add(positionOffset);
             this._teleportMyAvatar(position);
-
             this._myAvatar?.lookAt(avatar.position, Math.PI);
         }
     }
 
     public stopMyAvatar(): void {
-        const controller = this._myAvatar?.getComponent(
-            InputController.typeName
-        );
+        const controller = this._myAvatar?.getComponent(InputController.typeName);
         if (controller instanceof InputController) {
             controller.isStopped = true;
         }
@@ -673,6 +673,9 @@ export class VScene {
 
             this._sceneController = new SceneController(this);
             this._sceneManager.addComponent(this._sceneController);
+
+            this._interactionController = new InteractionController(this);
+            this._sceneManager.addComponent(this._interactionController);
         }
 
         if (this._domainController) {

--- a/src/stores/application-store.ts
+++ b/src/stores/application-store.ts
@@ -80,14 +80,14 @@ export const useApplicationStore = defineStore("application", {
             avatarsInfo: new Map<Uuid, AvatarInfo>()
         },
         messages: {
-            messages: [] as Array<ChatMessage>,
+            messages: new Array<ChatMessage>(),
             nextMessageId: 22,
             maxMessages: 150
         },
         // Information about the audio system.
         audio: {
-            inputsList: [] as Array<MediaDeviceInfo>,
-            outputsList: [] as Array<MediaDeviceInfo>,
+            inputsList: new Array<MediaDeviceInfo>(),
+            outputsList: new Array<MediaDeviceInfo>(),
             user: {
                 connected: false,
                 hasInputAccess: false,
@@ -153,7 +153,7 @@ export const useApplicationStore = defineStore("application", {
         },
         // Conference data.
         conference: {
-            activeRooms: [] as Array<JitsiRoomInfo>,
+            activeRooms: new Array<JitsiRoomInfo>(),
             currentRoom: {} as JitsiRoomInfo
         },
         // State of interactions with the player's avatar.

--- a/src/stores/application-store.ts
+++ b/src/stores/application-store.ts
@@ -18,6 +18,7 @@ import { DomainAudioClient } from "@Modules/domain/audio";
 import { DomainAvatarClient } from "@Modules/domain/avatar";
 import { AssignmentClientState } from "@Modules/domain/client";
 import { ConnectionState, Domain } from "@Modules/domain/domain";
+import { InteractionTarget } from "@Modules/avatar/controller/InteractionController";
 import type { ChatMessage } from "@Modules/domain/message";
 import type { WebEntity } from "@Modules/entity/entities";
 import type { IWebEntity } from "@Modules/entity/EntityInterfaces";
@@ -159,7 +160,8 @@ export const useApplicationStore = defineStore("application", {
         // State of interactions with the player's avatar.
         interactions: {
             interactionDistance: 1.5,
-            isInteracting: false
+            isInteracting: false,
+            targets: new Array<InteractionTarget>()
         }
     }),
 


### PR DESCRIPTION
This PR rewrites the sit/animate interaction system. The new system utilises the metadata in GLTF models to create more detailed interaction targets that don't require meshes.

The GLTF metadata contains the following properties:
| Property                           | Value Example    | Description                                  |
| :--------------------------------- | :--------------- | :------------------------------------------- |
| `vircadia_sit_[n]_position`        | `"0,0,0"`        | The position of the target, and the position the avatar will snap to when interacting. |
| `vircadia_sit_[n]_rotation`        | `"0,0,0"`        | The rotation the avatar will snap to when interacting. |
| `vircadia_sit_[n]_exit_position`   | `"0,0,0"`        | The position the avatar will snap to when the interaction has finished. |
| `vircadia_sit_[n]_text`            | `"Hello World"`  | The text to display on the label. |
| `vircadia_sit_[n]_icon`            | `"chair"`        | An [icon](https://fonts.google.com/icons?icon.set=Material+Icons) to display on the label. Overwrites the `text` property. |
| `vircadia_sit_[n]_color`           | `"#ff0000"`      | The color of the label. |
| `vircadia_sit_[n]_label_distance`  | `2`              | The distance at which the label should become visible to the avatar. |
| `vircadia_sit_[n]_animation`       | `"sit_default"`  | The avatar animation the interaction should trigger. |

The new system is also backwards-compatible with the old mesh-based system, so meshes with the name `animate_...` will still create interaction targets. One benefit of the old system is that - because interaction targets were attached to meshes - they themselves could be moved/animated. For example, attaching a target to the seat of a roller-coaster would pull the avatar along with the coaster. The new metadata-based system does not yet support this.